### PR TITLE
👌 IMPROVE: Move to new action, fixes #3 (#4) via @alpipego

### DIFF
--- a/template/release.yml
+++ b/template/release.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: WordPress Plugin Deploy
-        uses: 10up/actions-wordpress/dotorg-plugin-deploy@master
+        uses: 10up/action-wordpress-plugin-deploy@master
         env:
           GITHUB_TOKEN: ${{{{raw-helper}}}}{{ secrets.GITHUB_TOKEN }}{{{{/raw-helper}}}}
           SVN_USERNAME: ${{{{raw-helper}}}}{{ secrets.SVN_USERNAME }}{{{{/raw-helper}}}}


### PR DESCRIPTION
Updates action from `10up/actions-wordpress/dotorg-plugin-deploy` to `10up/action-wordpress-plugin-deploy@master`.